### PR TITLE
Fix #2 - Typo on project's URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>kasper-analytica-client</name>
-	<url>http://analityca.kleegroup.com</url>
+	<url>http://analytica.kleegroup.com</url>
 
 	<properties>
 		<compileSource>1.6</compileSource>


### PR DESCRIPTION
Fixed typo in URL. 

However, the provided URL is not publicly accessible.
